### PR TITLE
Addon attachment

### DIFF
--- a/lib/addons.js
+++ b/lib/addons.js
@@ -54,8 +54,11 @@ module.exports = function (app, log, client) {
             } else {
               return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]})
                 .then(function() {
-                  return app.addons(addonInfo.name).delete()
+                  return app.addons(addonInfo.name).delete();
                 })
+                .catch(function() {
+                  log('Failed to attach add-on: no such addon');
+                });
             }
           } else {
             return app.addons(addonName).update(updateParams(addonConfig));
@@ -64,8 +67,12 @@ module.exports = function (app, log, client) {
         function (err) {
           if (err && err.body && err.body.id == 'not_found') {
             return app.addons().create(addonConfig)
-              .catch(function() {
-                return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
+              .catch(function () {
+                log('Attaching add-on');
+                return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]})
+                  .catch(function() {
+                    log('Failed to attach add-on: no such addon');
+                  });
               });
           } else {
             throw err;

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -46,29 +46,30 @@ module.exports = function (app, log, client) {
 
   function createOrUpdate(addonConfig, addonName) {
     return app.addons(addonName).info().
-    then(
-      function (addonInfo) {
-        if (addonInfo.plan.name === addonConfig.plan) {
-          if (addonInfo.name === addonConfig.name) {
-            return;
+      then(
+        function (addonInfo) {
+          if (addonInfo.plan.name === addonConfig.plan) {
+            if (addonInfo.name === addonConfig.name) {
+              return;
+            } else {
+              return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]})
+                .then(function() {
+                  return app.addons(addonInfo.name).delete()
+                })
+            }
           } else {
-            return app.addons(addonInfo.name).delete().then(function () {
-              return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
-            });
+            return app.addons(addonName).update(updateParams(addonConfig));
           }
-        } else {
-          return app.addons(addonName).update(updateParams(addonConfig));
-        }
-      },
-      function (err) {
-        if (err && err.body && err.body.id == 'not_found') {
-          return app.addons().create(addonConfig)
-            .catch(function() {
-              return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
-            });
-        } else {
-          throw err;
-        }
+        },
+        function (err) {
+          if (err && err.body && err.body.id == 'not_found') {
+            return app.addons().create(addonConfig)
+              .catch(function() {
+                return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
+              });
+          } else {
+            throw err;
+          }
       });
   }
 

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -7,7 +7,7 @@ function updateParams(createParams) {
   };
 }
 
-module.exports = function (app, log) {
+module.exports = function (app, log, client) {
   function addonNames(configAddons) {
     return Object.keys(configAddons || {});
   }
@@ -46,17 +46,26 @@ module.exports = function (app, log) {
 
   function createOrUpdate(addonConfig, addonName) {
     return app.addons(addonName).info().
-      then(
+    then(
       function (addonInfo) {
         if (addonInfo.plan.name === addonConfig.plan) {
-          return;
+          if (addonInfo.name === addonConfig.name) {
+            return;
+          } else {
+            return app.addons(addonInfo.name).delete().then(function () {
+              return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
+            });
+          }
         } else {
           return app.addons(addonName).update(updateParams(addonConfig));
         }
       },
       function (err) {
         if (err && err.body && err.body.id == 'not_found') {
-          return app.addons().create(addonConfig);
+          return app.addons().create(addonConfig)
+            .catch(function() {
+              return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
+            });
         } else {
           throw err;
         }

--- a/lib/appConfigBuilder.js
+++ b/lib/appConfigBuilder.js
@@ -4,7 +4,9 @@ var util = require('./util');
 module.exports = function (config) {
 
   var addons = config.addons.map(function (addon) {
-    return [addon.addon_service.name, {plan: addon.plan.name}];
+    var addonSpec = {plan: addon.plan.name};
+    if (addon.name) {addonSpec.name = addon.name;}
+    return [addon.addon_service.name, addonSpec];
   });
 
   var addonsEnhancedWithPlugins = addons.map(function (pair) {

--- a/lib/heroin.js
+++ b/lib/heroin.js
@@ -95,10 +95,10 @@ module.exports = function (arg, options) {
     }
 
     return herokuClient.apps(config.name).info().
-    then(update, create).
-    then(configureApp).
-    then(printAppInfo).
-    catch(handleError);
+      then(update, create).
+      then(configureApp).
+      then(printAppInfo).
+      catch(handleError);
   };
 
   fn.delete = function (appName) {
@@ -120,6 +120,7 @@ module.exports = function (arg, options) {
   fn.export = function (appName) {
     var app = herokuClient.apps(appName);
     var organizationApp = herokuClient.organizations().apps(appName);
+
     var exportActions = [];
     exportActions.push(appInfo(organizationApp).export());
     exportActions.push.apply(exportActions, [configVars, addons, collaborators, features, formation, logDrains, domains].map(function (fn) {

--- a/lib/heroin.js
+++ b/lib/heroin.js
@@ -51,7 +51,7 @@ module.exports = function (arg, options) {
       var app = herokuClient.apps(config.name);
       var setConfigVars = configVars(app, log).configure(config.config_vars);
       var setAddonsPlugins = _.partial(addonsPlugins(plugins, log).configure, config.addons);
-      var setAddons = addons(app, log).configure(config.addons, plugins).then(function () {
+      var setAddons = addons(app, log, herokuClient).configure(config.addons, plugins).then(function () {
         return setConfigVars;
       }).then(setAddonsPlugins);
       var setCollaborators = collaborators(app, log).configure(config.collaborators);
@@ -95,10 +95,10 @@ module.exports = function (arg, options) {
     }
 
     return herokuClient.apps(config.name).info().
-      then(update, create).
-      then(configureApp).
-      then(printAppInfo).
-      catch(handleError);
+    then(update, create).
+    then(configureApp).
+    then(printAppInfo).
+    catch(handleError);
   };
 
   fn.delete = function (appName) {
@@ -120,7 +120,6 @@ module.exports = function (arg, options) {
   fn.export = function (appName) {
     var app = herokuClient.apps(appName);
     var organizationApp = herokuClient.organizations().apps(appName);
-
     var exportActions = [];
     exportActions.push(appInfo(organizationApp).export());
     exportActions.push.apply(exportActions, [configVars, addons, collaborators, features, formation, logDrains, domains].map(function (fn) {

--- a/test_integration/appIntegrationTest.js
+++ b/test_integration/appIntegrationTest.js
@@ -38,7 +38,7 @@ var updatedAppConfig = {
   },
   addons: {
     librato: {plan: 'librato:development', name: 'updated-app-librato'},
-    logentries: {plan: 'logentries:le_tryit', name: 'sample-logentries'},
+    logentries: {plan: 'logentries:le_tryit', name: 'updated-logentries'},
     'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
   },
   collaborators: ['mateusz.kwasniewski@schibsted.pl'],

--- a/test_integration/appIntegrationTest.js
+++ b/test_integration/appIntegrationTest.js
@@ -3,7 +3,9 @@ var chai = require('chai'),
   heroin = require('../lib/heroin'),
   _ = require('lodash');
 
-var appName = 'sample-heroin-app';
+var appName = 'sample-heroin-application';
+var anotherAppName = 'another-heroin-application';
+var yetAnotherAppName = 'yet-another-heroin-application';
 var configurator = heroin(process.env.HEROKU_API_TOKEN);
 
 var sampleAppConfig = {
@@ -15,7 +17,9 @@ var sampleAppConfig = {
     NODE_ENV: 'production',
     FEATURE_FLAG: 'true'
   },
-  addons: {logentries: {plan: 'logentries:le_tryit'}},
+  addons: {
+    logentries: {plan: 'logentries:le_tryit', name: 'sample-logentries'}
+  },
   collaborators: ['mateusz.kwasniewski@schibsted.pl'],
   features: {
     'log-runtime-metrics': {enabled: true},
@@ -29,10 +33,14 @@ var updatedAppConfig = {
   maintenance: true,
   stack: 'cedar-14',
   config_vars: {
-    NODE_ENV: 'development',
+    NODE_ENV: 'production',
     ANOTHER_FEATURE_FLAG: 'true'
   },
-  addons: {librato: {plan: 'librato:development'}},
+  addons: {
+    librato: {plan: 'librato:development', name: 'updated-app-librato'},
+    logentries: {plan: 'logentries:le_tryit', name: 'sample-logentries'},
+    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
+  },
   collaborators: ['mateusz.kwasniewski@schibsted.pl'],
   features: {
     'log-runtime-metrics': {enabled: false},
@@ -40,49 +48,150 @@ var updatedAppConfig = {
   formation: [{process: 'web', quantity: 1, size: 'Free'}]
 };
 
+var anotherAppConfig = {
+  name: anotherAppName,
+  region: 'eu',
+  maintenance: false,
+  stack: 'cedar-14',
+  config_vars: {
+    NODE_ENV: 'development',
+  },
+  addons: {
+    'heroku-redis': {plan: 'heroku-redis:hobby-dev'}
+  },
+  collaborators: ['patryk.mrukot@schibsted.pl'],
+  formation: [{process: 'web', quantity: 1, size: 'Free'}]
+};
+
+var updatedAnotherAppConfig = {
+  name: anotherAppName,
+  region: 'eu',
+  maintenance: true,
+  stack: 'cedar-14',
+  config_vars: {
+    NODE_ENV: 'production',
+  },
+  addons: {
+    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
+  },
+  collaborators: ['patryk.mrukot@schibsted.pl'],
+  formation: [{process: 'web', quantity: 1, size: 'Free'}]
+};
+
+var yetAnotherAppConfig = {
+  name: yetAnotherAppName,
+  region: 'eu',
+  maintenance: false,
+  stack: 'cedar-14',
+  config_vars: {
+    NODE_ENV: 'production',
+  },
+  addons: {
+    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
+  },
+  collaborators: ['patryk.mrukot@schibsted.pl'],
+  formation: [{process: 'web', quantity: 1, size: 'Free'}]
+};
+
+var deleteApp = function(appName) {
+  return configurator.delete(appName)
+    .then(function () {
+      console.log('Deleted app');
+    }, function (err) {
+      console.error('Could not delete app ', err);
+    });
+};
 
 describe('HeroIn', function () {
 
-  beforeEach(function (done) {
+  before(function (done) {
     this.timeout(30000);
 
-    configurator.delete(appName).then(function () {
-        console.log('deleted app');
-        done();
-      }, function (err) {
-        console.error('could not delete app ', err);
-        done();
-      }
-    );
+    deleteApp(appName)
+      .then(deleteApp(anotherAppName))
+      .then(deleteApp(yetAnotherAppName))
+      .then(done)
+      .catch(done);
+  });
+
+  after(function (done) {
+    this.timeout(30000);
+
+    deleteApp(appName)
+      .then(deleteApp(anotherAppName))
+      .then(deleteApp(yetAnotherAppName))
+      .then(done)
+      .catch(done);
   });
 
   it('should provide full Heroku infrastructure lifecycle', function (done) {
-    this.timeout(40000);
+    this.timeout(50000);
 
     configurator(sampleAppConfig).
-      then(function () {
-        return configurator.export(appName);
-      }).
-      then(function (actualAppConfig) {
-        assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
-        assert.equal(actualAppConfig.addons.logentries.plan, 'logentries:le_tryit');
-        assert.equal(actualAppConfig.maintenance, false);
-      }).
-      then(function() {
-        return configurator(updatedAppConfig);
-      }).
-      then(function () {
-        return configurator.export(appName);
-      }).
-      then(function(actualAppConfig) {
-        assert.equal(actualAppConfig.config_vars.NODE_ENV, 'development');
-        assert.equal(actualAppConfig.addons.librato.plan, 'librato:development');
-        assert.equal(actualAppConfig.maintenance, true);
-      }).
-      then(done).
-      catch(done);
+    then(function() {
+      return configurator.export(appName);
+    }).
+    then(function (actualAppConfig) {
+      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
+      assert.equal(actualAppConfig.addons.logentries.plan, 'logentries:le_tryit');
+      assert.equal(actualAppConfig.addons.logentries.name, 'sample-logentries');
+      assert.equal(actualAppConfig.maintenance, false);
+    }).
+    then(function() {
+      return configurator(updatedAppConfig);
+    }).
+    then(function() {
+      return configurator.export(appName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
+      assert.equal(actualAppConfig.addons.librato.plan, 'librato:development');
+      assert.equal(actualAppConfig.addons.librato.name, 'updated-app-librato');
+      assert.equal(actualAppConfig.addons.logentries.plan, 'logentries:le_tryit');
+      assert.equal(actualAppConfig.addons.logentries.name, 'sample-logentries');
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
+      assert.equal(actualAppConfig.maintenance, true);
+    }).
+    then(function() {
+      return configurator(anotherAppConfig);
+    }).
+    then(function() {
+      return configurator.export(anotherAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'development');
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name.split('-')[0], 'redis');
+      assert.equal(actualAppConfig.maintenance, false);
+    }).
+    then(function() {
+      return configurator(updatedAnotherAppConfig);
+    }).
+    then(function() {
+      return configurator.export(anotherAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
+      assert.equal(actualAppConfig.maintenance, true);
+    }).
+    then(function() {
+      return configurator(yetAnotherAppConfig);
+    }).
+    then(function() {
+      return configurator.export(yetAnotherAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
+      assert.equal(actualAppConfig.maintenance, false);
+    }).
+    then(done).
+    catch(done);
   });
-
 
 });
 

--- a/test_integration/pipelineIntegrationTest.js
+++ b/test_integration/pipelineIntegrationTest.js
@@ -4,12 +4,12 @@ var chai = require('chai'),
   _ = require('lodash');
 
 var configurator = heroin(process.env.HEROKU_API_TOKEN);
-var pipelineName = 'sample-heroin-pipeline';
-var reviewApp = 'sample-heroin-review-app';
-var newReviewApp = 'new-sample-heroin-review-app';
-var developmentApp = 'sample-heroin-development-app';
-var stagingApp = 'sample-heroin-staging-app';
-var productionApp = 'sample-heroin-production-app';
+var pipelineName = 'heroin-pipeline';
+var reviewApp = 'heroin-reviewing-app';
+var newReviewApp = 'heroin-review-app';
+var developmentApp = 'heroin-development-app';
+var stagingApp = 'heroin-staging-app';
+var productionApp = 'heroin-production-app';
 var apps = [reviewApp, newReviewApp, developmentApp, stagingApp, productionApp];
 
 var pipelineConfig = {
@@ -23,7 +23,17 @@ var updatedPipelineConfig = {
 };
 
 describe('HeroIn', function () {
-  beforeEach(function (done) {
+  before(function (done) {
+    this.timeout(30000);
+
+    Promise.all(apps.map(configurator.delete)).then(function () {
+      console.log('Deleted all test apps');
+    }, function (err) {
+      console.error('Could not delete apps', err);
+    }).then(done);
+  });
+
+  after(function (done) {
     this.timeout(30000);
 
     Promise.all(apps.map(configurator.delete)).then(function () {
@@ -38,34 +48,34 @@ describe('HeroIn', function () {
 
     Promise.all(
       apps.
-        map(function (name) {
-          return {name: name};
-        }).
-        map(configurator)
+      map(function (name) {
+        return {name: name};
+      }).
+      map(configurator)
     ).
-      then(function () {
-        return configurator.pipeline(pipelineConfig); // create new pipeline
-      }).
-      then(function () {
-        return configurator.pipeline(pipelineConfig); // no op update
-      }).
-      then(function () {
-        return configurator.pipeline(pipelineName);
-      }).
-      then(function (actualPipelineConfig) {
-        assert.deepEqual(actualPipelineConfig, pipelineConfig);
-      }).
-      then(function() {
-        return configurator.pipeline(updatedPipelineConfig);
-      }).
-      then(function() {
-        return configurator.pipeline(pipelineName);
-      }).
-      then(function (actualPipelineConfig) {
-        assert.deepEqual(actualPipelineConfig, updatedPipelineConfig);
-      }).
-      then(done).
-      catch(done);
+    then(function () {
+      return configurator.pipeline(pipelineConfig); // create new pipeline
+    }).
+    then(function () {
+      return configurator.pipeline(pipelineConfig); // no op update
+    }).
+    then(function () {
+      return configurator.pipeline(pipelineName);
+    }).
+    then(function (actualPipelineConfig) {
+      assert.deepEqual(actualPipelineConfig, pipelineConfig);
+    }).
+    then(function() {
+      return configurator.pipeline(updatedPipelineConfig);
+    }).
+    then(function() {
+      return configurator.pipeline(pipelineName);
+    }).
+    then(function (actualPipelineConfig) {
+      assert.deepEqual(actualPipelineConfig, updatedPipelineConfig);
+    }).
+    then(done).
+    catch(done);
   });
 });
 


### PR DESCRIPTION
**PREFACE:**
This PR is about making attaching add-ons automated process. Since heroku-client is not supporting it and Heroku API Reference says it has prototype status ([reference](https://devcenter.heroku.com/articles/platform-api-reference#add-on-attachment)) it needs to be done from Heroku client level, not app level.

**CHANGES:**
Main change is in `addons.js`. 

First we need to pass client from `heroin.js` so we can make a call to attach addon. Now, during creating/updating an add-on we have two cases:

1) _[update-level]_ Assuming we usually do not provide custom name and let Heroku generate it, our configuration object looks like:

Before attaching add-on:

```
addons: {
   librato: {plan: 'librato:development'}
}
```

After attaching add-on:

```
addons: {
   librato: {plan: 'librato:development', name: ‘sample-reference-name’},
}
```

When we are updating existing addon, and `plan` attribute of an addon stays the same, and we change a `name` attribute, HeroIn will attach an existing add-on from another app (which we passed), and delete the old one. 
Name is assumed to be a reference-name of an add-on we would like to attach. If ref-name that does not exist is provided - an exception is caught and nothing happens.
It also works when we actually have a custom ref-name for add-on.

Otherwise, If plan changed we just update addon (just as before)

2) _[creation-level]_ When addon does not exist and we would like to create an attached one, we expect app.addons.create() to throw an error since you cannot have two add-ons with same reference-name. Then the exception is caught and we make a call to attach an add-on.

**OTHER CHANGES:**
1) Passing herokuClient to `addons.js` so we can make a call to attach add-on.
2) Add name parameter to add-object in `appConfigBuilder.js` so we can check if everything works correctly.

**TESTS:**
I modified main integration test. Before it created an application and updated it. Now it creates 3 applications.

The first one is created and updated just as before.

Second one covers our first case - we create an application with redis add-on, and then we are updating our add-on since we would like to have same redis add-on, but attached from the first app. _[update-level]_

And the third one covers our second case - we create an application and attach an add-on immediately from the first app. _[creation-level]_

And it seems I needed to change names of test applications in `pipelineIntegrationTests.js` since it was throwing an error that such names already exist + added `after` to delete applications after running tests.
