### PR TITLE
Improving addon-attachment behaviour: when renaming addon remove old …

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,5 +2,6 @@
   /* disabling some warnings due to disagreement with some of JSHint's default opinions */
 
   "-W069": true, /* using ['blah'] is OK over the dot notation if we expect the thing to not be there */
-  "-W041": true  /* == 0 is OK when we want to show intent */
+  "-W041": true,  /* == 0 is OK when we want to show intent */
+  "esnext": true /* enabling template literals for logs in addon attachment */
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "6.0.0"
   - "iojs"
 before_script:
   - npm run lint

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -49,16 +49,21 @@ module.exports = function (app, log, client) {
       then(
         function (addonInfo) {
           if (addonInfo.plan.name === addonConfig.plan) {
-            if (addonInfo.name === addonConfig.name) {
-              return;
-            } else {
+            if (addonInfo.name !== addonConfig.name) {
+              log(`Addon name changed from ${addonInfo.name} to ${addonConfig.name}`);
+              log('Attempting to attach addon');
               return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]})
-                .then(function() {
-                  return app.addons(addonInfo.name).delete();
-                })
-                .catch(function() {
-                  log('Failed to attach add-on: no such addon');
-                });
+                  .then(function () {
+                    log(`Addon attachment with name ${addonConfig.name} successful, deleting ${addonInfo.name}`);
+                    return app.addons(addonInfo.name).delete();
+                  })
+                  .catch(function (err) {
+                    log(`Addon with name ${addonConfig.name} does not exist, deleting existing addon and creating one with new name`);
+                    return app.addons(addonInfo.name).delete()
+                      .then(function () {
+                        return app.addons().create(addonConfig);
+                      });
+                  });
             }
           } else {
             return app.addons(addonName).update(updateParams(addonConfig));
@@ -68,11 +73,8 @@ module.exports = function (app, log, client) {
           if (err && err.body && err.body.id == 'not_found') {
             return app.addons().create(addonConfig)
               .catch(function () {
-                log('Attaching add-on');
-                return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]})
-                  .catch(function() {
-                    log('Failed to attach add-on: no such addon');
-                  });
+                log(`Addon with name ${addonName} not found in current app, attaching it from another app`);
+                return client.post('/addon-attachments', {addon: addonConfig.name, app: app.params[0]});
               });
           } else {
             throw err;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:coverage": "istanbul cover node_modules/mocha/bin/_mocha --dir ./coverage --report lcov -- -R spec --recursive --timeout 7000 ./test",
     "lint": "jshint --exclude=node_modules **/*.js"
   },
+  "engines" : { "node" : ">=6.0.0" },
   "keywords": [
     "heroku",
     "infrastructure",

--- a/test_integration/addonsIntegrationTest.js
+++ b/test_integration/addonsIntegrationTest.js
@@ -1,0 +1,166 @@
+var chai = require('chai'),
+  assert = chai.assert,
+  heroin = require('../lib/heroin'),
+  _ = require('lodash');
+
+var configurator = heroin(process.env.HEROKU_API_TOKEN);
+
+var baseAppName = 'base-heroin-application';
+var testAppName = 'test-heroin-application';
+
+var baseAppConfig = {
+  name: baseAppName,
+  region: 'eu',
+  maintenance: false,
+  stack: 'cedar-14',
+  config_vars: {
+    NODE_ENV: 'production'
+  },
+  addons: {
+    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'base-heroin-redis'}
+  },
+  collaborators: ['patryk.mrukot@schibsted.pl'],
+  features: {
+    'log-runtime-metrics': {enabled: true}
+  },
+  formation: [{process: 'web', quantity: 1, size: 'Free'}]
+};
+
+var testAppConfig = {
+  name: testAppName,
+  region: 'eu',
+  maintenance: false,
+  stack: 'cedar-14',
+  config_vars: {
+    NODE_ENV: 'production'
+  },
+  addons: {},
+  collaborators: ['patryk.mrukot@schibsted.pl'],
+  features: {
+    'log-runtime-metrics': {enabled: true}
+  },
+  formation: [{process: 'web', quantity: 1, size: 'Free'}]
+};
+
+var deleteApp = function(appName) {
+  return configurator.delete(appName)
+    .then(function () {
+      console.log('Deleted app');
+    }, function (err) {
+      console.error('Could not delete app ', err);
+    });
+};
+
+describe('HeroIn', function () {
+
+  before(function (done) {
+    this.timeout(10000);
+
+    deleteApp(baseAppName)
+      .then(deleteApp(testAppName))
+      .then(configurator(baseAppConfig))
+      .then(done)
+      .catch(done);
+  });
+
+  after(function (done) {
+    this.timeout(10000);
+
+    deleteApp(baseAppName)
+      .then(deleteApp(testAppName))
+      .then(done)
+      .catch(done);
+  });
+
+  afterEach(function (done) {
+    this.timeout(10000);
+
+    deleteApp(testAppName)
+      .then(done)
+      .catch(done);
+  });
+
+  it('should delete old addon and create a fresh one when providing a new addon name', function(done) {
+    this.timeout(10000);
+
+    var updatedTestAppConfig = Object.assign({}, testAppConfig, {
+      addons: {
+        'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'updated-test-heroin-redis'}
+      }
+    });
+
+    configurator(updatedTestAppConfig).
+    then(function() {
+      return configurator.export(testAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'updated-test-heroin-redis');
+    }).
+    then(done).
+    catch(done);
+  });
+
+  it('should successfully attach addon from another app when its name is provided and delete old one', function(done) {
+    this.timeout(10000);
+
+    var updatedTestAppConfig = Object.assign({}, testAppConfig, {
+      addons: {
+        'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'base-heroin-redis'}
+      }
+    });
+
+    configurator(updatedTestAppConfig).
+    then(function() {
+      return configurator.export(testAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'base-heroin-redis');
+    }).
+    then(done).
+    catch(done);
+  });
+
+  it('should create an addon for an app if it doesnt exist', function(done) {
+    this.timeout(10000);
+
+    var updatedTestAppConfig = Object.assign({}, testAppConfig, {
+      addons: {'heroku-redis': {plan: 'heroku-redis:hobby-dev'}}
+    });
+
+    configurator(updatedTestAppConfig).
+    then(function() {
+      return configurator.export(testAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name.split('-')[0], 'redis');
+    }).
+    then(done).
+    catch(done);
+  });
+
+  it('should attach an addon if an app has no addon of that type, but the name is taken', function(done) {
+    this.timeout(10000);
+
+    var updatedTestAppConfig = Object.assign({}, testAppConfig, {
+      addons: {'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'base-heroin-redis'}}
+    });
+
+    configurator(testAppConfig).
+    then(function() {
+      return configurator(updatedTestAppConfig);
+    }).
+    then(function() {
+      return configurator.export(testAppName);
+    }).
+    then(function(actualAppConfig) {
+      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
+      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'base-heroin-redis');
+    }).
+    then(done).
+    catch(done);
+  });
+
+});

--- a/test_integration/appIntegrationTest.js
+++ b/test_integration/appIntegrationTest.js
@@ -3,9 +3,7 @@ var chai = require('chai'),
   heroin = require('../lib/heroin'),
   _ = require('lodash');
 
-var appName = 'sample-heroin-application';
-var anotherAppName = 'another-heroin-application';
-var yetAnotherAppName = 'yet-another-heroin-application';
+var appName = 'test-lifecycle-heroin-app';
 var configurator = heroin(process.env.HEROKU_API_TOKEN);
 
 var sampleAppConfig = {
@@ -18,7 +16,7 @@ var sampleAppConfig = {
     FEATURE_FLAG: 'true'
   },
   addons: {
-    logentries: {plan: 'logentries:le_tryit', name: 'sample-logentries'}
+    logentries: {plan: 'logentries:le_tryit'}
   },
   collaborators: ['mateusz.kwasniewski@schibsted.pl'],
   features: {
@@ -33,13 +31,11 @@ var updatedAppConfig = {
   maintenance: true,
   stack: 'cedar-14',
   config_vars: {
-    NODE_ENV: 'production',
+    NODE_ENV: 'development',
     ANOTHER_FEATURE_FLAG: 'true'
   },
   addons: {
-    librato: {plan: 'librato:development', name: 'updated-app-librato'},
-    logentries: {plan: 'logentries:le_tryit', name: 'updated-logentries'},
-    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
+    librato: {plan: 'librato:development'}
   },
   collaborators: ['mateusz.kwasniewski@schibsted.pl'],
   features: {
@@ -48,151 +44,48 @@ var updatedAppConfig = {
   formation: [{process: 'web', quantity: 1, size: 'Free'}]
 };
 
-var anotherAppConfig = {
-  name: anotherAppName,
-  region: 'eu',
-  maintenance: false,
-  stack: 'cedar-14',
-  config_vars: {
-    NODE_ENV: 'development',
-  },
-  addons: {
-    'heroku-redis': {plan: 'heroku-redis:hobby-dev'}
-  },
-  collaborators: ['patryk.mrukot@schibsted.pl'],
-  formation: [{process: 'web', quantity: 1, size: 'Free'}]
-};
-
-var updatedAnotherAppConfig = {
-  name: anotherAppName,
-  region: 'eu',
-  maintenance: true,
-  stack: 'cedar-14',
-  config_vars: {
-    NODE_ENV: 'production',
-  },
-  addons: {
-    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
-  },
-  collaborators: ['patryk.mrukot@schibsted.pl'],
-  formation: [{process: 'web', quantity: 1, size: 'Free'}]
-};
-
-var yetAnotherAppConfig = {
-  name: yetAnotherAppName,
-  region: 'eu',
-  maintenance: false,
-  stack: 'cedar-14',
-  config_vars: {
-    NODE_ENV: 'production',
-  },
-  addons: {
-    'heroku-redis': {plan: 'heroku-redis:hobby-dev', name: 'heroin-sample-redis'}
-  },
-  collaborators: ['patryk.mrukot@schibsted.pl'],
-  formation: [{process: 'web', quantity: 1, size: 'Free'}]
-};
-
-var deleteApp = function(appName) {
-  return configurator.delete(appName)
-    .then(function () {
-      console.log('Deleted app');
-    }, function (err) {
-      console.error('Could not delete app ', err);
-    });
-};
 
 describe('HeroIn', function () {
 
-  before(function (done) {
+  beforeEach(function (done) {
     this.timeout(30000);
 
-    deleteApp(appName)
-      .then(deleteApp(anotherAppName))
-      .then(deleteApp(yetAnotherAppName))
-      .then(done)
-      .catch(done);
-  });
-
-  after(function (done) {
-    this.timeout(30000);
-
-    deleteApp(appName)
-      .then(deleteApp(anotherAppName))
-      .then(deleteApp(yetAnotherAppName))
-      .then(done)
-      .catch(done);
+    configurator.delete(appName).then(function () {
+        console.log('deleted app');
+        done();
+      }, function (err) {
+        console.error('could not delete app ', err);
+        done();
+      }
+    );
   });
 
   it('should provide full Heroku infrastructure lifecycle', function (done) {
-    this.timeout(50000);
+    this.timeout(40000);
 
     configurator(sampleAppConfig).
-    then(function() {
+    then(function () {
       return configurator.export(appName);
     }).
     then(function (actualAppConfig) {
       assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
       assert.equal(actualAppConfig.addons.logentries.plan, 'logentries:le_tryit');
-      assert.equal(actualAppConfig.addons.logentries.name, 'sample-logentries');
       assert.equal(actualAppConfig.maintenance, false);
     }).
     then(function() {
       return configurator(updatedAppConfig);
     }).
-    then(function() {
+    then(function () {
       return configurator.export(appName);
     }).
     then(function(actualAppConfig) {
-      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
-      assert.equal(actualAppConfig.addons.librato.plan, 'librato:development');
-      assert.equal(actualAppConfig.addons.librato.name, 'updated-app-librato');
-      assert.equal(actualAppConfig.addons.logentries.plan, 'logentries:le_tryit');
-      assert.equal(actualAppConfig.addons.logentries.name, 'sample-logentries');
-      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
-      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
-      assert.equal(actualAppConfig.maintenance, true);
-    }).
-    then(function() {
-      return configurator(anotherAppConfig);
-    }).
-    then(function() {
-      return configurator.export(anotherAppName);
-    }).
-    then(function(actualAppConfig) {
       assert.equal(actualAppConfig.config_vars.NODE_ENV, 'development');
-      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
-      assert.equal(actualAppConfig.addons['heroku-redis'].name.split('-')[0], 'redis');
-      assert.equal(actualAppConfig.maintenance, false);
-    }).
-    then(function() {
-      return configurator(updatedAnotherAppConfig);
-    }).
-    then(function() {
-      return configurator.export(anotherAppName);
-    }).
-    then(function(actualAppConfig) {
-      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
-      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
-      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
+      assert.equal(actualAppConfig.addons.librato.plan, 'librato:development');
       assert.equal(actualAppConfig.maintenance, true);
-    }).
-    then(function() {
-      return configurator(yetAnotherAppConfig);
-    }).
-    then(function() {
-      return configurator.export(yetAnotherAppName);
-    }).
-    then(function(actualAppConfig) {
-      assert.equal(actualAppConfig.config_vars.NODE_ENV, 'production');
-      assert.equal(actualAppConfig.addons['heroku-redis'].plan, 'heroku-redis:hobby-dev');
-      assert.equal(actualAppConfig.addons['heroku-redis'].name, 'heroin-sample-redis');
-      assert.equal(actualAppConfig.maintenance, false);
     }).
     then(done).
     catch(done);
   });
 
+
 });
-
-

--- a/test_integration/pipelineIntegrationTest.js
+++ b/test_integration/pipelineIntegrationTest.js
@@ -4,6 +4,7 @@ var chai = require('chai'),
   _ = require('lodash');
 
 var configurator = heroin(process.env.HEROKU_API_TOKEN);
+
 var pipelineName = 'heroin-pipeline';
 var reviewApp = 'heroin-reviewing-app';
 var newReviewApp = 'heroin-review-app';


### PR DESCRIPTION
Some major improvements to add-on attachment features:
* Renaming/providing a name for an add-on:
a) attaches add-on from another app (if add-on with provided name is found)
b) deletes existing add-on and creates a new one with provided name (if add-on with such name doesn't exist yet)
* Add-on attachment failure now crashes the app
* Added complex logging to add-on attachment, since its stability according to heroku api docs is prototype
* Changed appIntegrationTest.js to previous version and moved testing add-on attachment to separate file (addonsIntegrationTest.js) to reduce redundancy.
* Added `esnext` flag to jshint to enable template literals
* Changed node engine in travis and package.json to 6.0.0 to support template literals